### PR TITLE
Add basic gig/event/comic tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-cat <<EOF > .gitignore
-# Go stuff
+# Go build artifacts
 *.exe
 *.out
 *.test
@@ -9,7 +8,5 @@ cat <<EOF > .gitignore
 .idea/
 .DS_Store
 
-# Data
-data/comics.json
-EOF
-
+# Data files
+data/*.json

--- a/main.go
+++ b/main.go
@@ -6,53 +6,186 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
 )
 
+// Comic represents a comedian that can be booked for events.
 type Comic struct {
-	Name  string `json:"name"`
-	Date  string `json:"date"`
-	Paid  bool   `json:"paid"`
-	Notes string `json:"notes"`
+	ID         int    `json:"id"`
+	Name       string `json:"name"`
+	Contact    string `json:"contact"`
+	DefaultFee int    `json:"default_fee"`
+	Notes      string `json:"notes"`
 }
 
-var comics []Comic
+// EventComic stores event specific info about a comic.
+type EventComic struct {
+	ComicID int    `json:"comic_id"`
+	Fee     int    `json:"fee"`
+	Paid    bool   `json:"paid"`
+	Notes   string `json:"notes"`
+}
 
-func loadComics() {
-	file, err := os.ReadFile("data/comics.json")
+// Event represents a single comedy night.
+type Event struct {
+	ID       int          `json:"id"`
+	GigID    int          `json:"gig_id"`
+	Date     string       `json:"date"`
+	Time     string       `json:"time"`
+	Timeline string       `json:"timeline"`
+	Comics   []EventComic `json:"comics"`
+}
+
+// Gig is a recurring show at a venue.
+type Gig struct {
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Venue       string `json:"venue"`
+	Address     string `json:"address"`
+	Description string `json:"description"`
+	Instagram   string `json:"instagram"`
+	Contact     string `json:"contact"`
+}
+
+// Data is the on-disk representation of the application database.
+type Data struct {
+	Comics []Comic `json:"comics"`
+	Events []Event `json:"events"`
+	Gigs   []Gig   `json:"gigs"`
+}
+
+var db Data
+
+func dataFile() string {
+	return filepath.Join("data", "app.json")
+}
+
+func loadData() {
+	file, err := os.ReadFile(dataFile())
 	if err != nil {
 		log.Println("No existing data file, starting fresh.")
-		comics = []Comic{}
+		// seed with default gig
+		db = Data{
+			Gigs: []Gig{{
+				ID:          1,
+				Name:        "Comedy at CoConspirators",
+				Venue:       "CoConspirators Brewing Co.",
+				Address:     "Brunswick",
+				Description: "Monthly comedy night at CoConspirators",
+			}},
+		}
 		return
 	}
-	json.Unmarshal(file, &comics)
+	json.Unmarshal(file, &db)
 }
 
-func saveComics() {
-	data, _ := json.MarshalIndent(comics, "", "  ")
-	os.WriteFile("data/comics.json", data, 0644)
+func saveData() {
+	os.MkdirAll("data", 0755)
+	data, _ := json.MarshalIndent(db, "", "  ")
+	os.WriteFile(dataFile(), data, 0644)
 }
 
+// indexHandler lists events for the first gig and allows adding new ones.
 func indexHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		r.ParseForm()
-		comics = append(comics, Comic{
-			Name:  r.FormValue("name"),
-			Date:  r.FormValue("date"),
-			Paid:  r.FormValue("paid") == "on",
-			Notes: r.FormValue("notes"),
+		id := len(db.Events) + 1
+		db.Events = append(db.Events, Event{
+			ID:       id,
+			GigID:    1,
+			Date:     r.FormValue("date"),
+			Time:     r.FormValue("time"),
+			Timeline: r.FormValue("timeline"),
 		})
-		saveComics()
+		saveData()
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 		return
 	}
 
 	tmpl := template.Must(template.ParseFiles("templates/index.html"))
-	tmpl.Execute(w, comics)
+	var events []Event
+	for _, e := range db.Events {
+		if e.GigID == 1 {
+			events = append(events, e)
+		}
+	}
+	tmpl.Execute(w, struct {
+		Gig    Gig
+		Events []Event
+	}{db.Gigs[0], events})
+}
+
+// comicsHandler lists comics and allows adding new ones.
+func comicsHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodPost {
+		r.ParseForm()
+		id := len(db.Comics) + 1
+		fee, _ := strconv.Atoi(r.FormValue("fee"))
+		db.Comics = append(db.Comics, Comic{
+			ID:         id,
+			Name:       r.FormValue("name"),
+			Contact:    r.FormValue("contact"),
+			DefaultFee: fee,
+			Notes:      r.FormValue("notes"),
+		})
+		saveData()
+		http.Redirect(w, r, "/comics", http.StatusSeeOther)
+		return
+	}
+
+	tmpl := template.Must(template.ParseFiles("templates/comics.html"))
+	tmpl.Execute(w, db.Comics)
+}
+
+// eventHandler manages a single event and its lineup.
+func eventHandler(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get("id"))
+	var event *Event
+	for i := range db.Events {
+		if db.Events[i].ID == id {
+			event = &db.Events[i]
+			break
+		}
+	}
+	if event == nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	if r.Method == http.MethodPost {
+		r.ParseForm()
+		comicID, _ := strconv.Atoi(r.FormValue("comic_id"))
+		fee, _ := strconv.Atoi(r.FormValue("fee"))
+		event.Comics = append(event.Comics, EventComic{
+			ComicID: comicID,
+			Fee:     fee,
+			Paid:    r.FormValue("paid") == "on",
+			Notes:   r.FormValue("notes"),
+		})
+		saveData()
+		http.Redirect(w, r, r.URL.String(), http.StatusSeeOther)
+		return
+	}
+
+	comicMap := make(map[int]Comic)
+	for _, c := range db.Comics {
+		comicMap[c.ID] = c
+	}
+
+	tmpl := template.Must(template.ParseFiles("templates/event.html"))
+	tmpl.Execute(w, struct {
+		Event    *Event
+		Comics   []Comic
+		ComicMap map[int]Comic
+	}{event, db.Comics, comicMap})
 }
 
 func main() {
-	loadComics()
+	loadData()
 	http.HandleFunc("/", indexHandler)
+	http.HandleFunc("/comics", comicsHandler)
+	http.HandleFunc("/event", eventHandler)
 	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
 	log.Println("🚀 cammcomedy running at http://localhost:8101")
 	http.ListenAndServe(":8101", nil)

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
 body {
   font-family: system-ui, sans-serif;
-  max-width: 600px;
+  max-width: 700px;
   margin: 2rem auto;
   padding: 0 1rem;
   background: #fdfdfd;
@@ -19,5 +19,21 @@ form {
   margin-bottom: 2rem;
   padding: 1rem;
   background: #fff;
-  border: 1px sol
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
 
+ul {
+  list-style: none;
+  padding: 0;
+}
+
+li {
+  margin-bottom: 0.5rem;
+}
+
+label {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}

--- a/templates/comics.html
+++ b/templates/comics.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Comics</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <h1>Comics</h1>
+  <form method="POST">
+    <input name="name" placeholder="Name" required>
+    <input name="contact" placeholder="Contact">
+    <input name="fee" type="number" value="25" placeholder="Default Fee">
+    <input name="notes" placeholder="Notes">
+    <button type="submit">Add Comic</button>
+  </form>
+  <ul>
+    {{range .}}
+    <li>{{.Name}} – {{.Contact}} (${{.DefaultFee}}) {{.Notes}}</li>
+    {{end}}
+  </ul>
+  <p><a href="/">Back to events</a></p>
+</body>
+</html>

--- a/templates/event.html
+++ b/templates/event.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Event {{.Event.Date}}</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <h1>{{.Event.Date}} {{.Event.Time}}</h1>
+  <p>{{.Event.Timeline}}</p>
+  <h2>Add Comic</h2>
+  <form method="POST">
+    <select name="comic_id">
+      {{range .Comics}}
+      <option value="{{.ID}}">{{.Name}}</option>
+      {{end}}
+    </select>
+    <input name="fee" type="number" value="25" placeholder="Fee">
+    <label><input type="checkbox" name="paid"> Paid</label>
+    <input name="notes" placeholder="Notes">
+    <button type="submit">Add Comic</button>
+  </form>
+  <h2>Lineup</h2>
+  <ul>
+    {{range .Event.Comics}}
+      {{ $comic := index $.ComicMap .ComicID }}
+      <li>{{$comic.Name}} – ${{.Fee}} {{if .Paid}}✅{{else}}💸{{end}} {{.Notes}}</li>
+    {{end}}
+  </ul>
+  <p><a href="/">Back</a> | <a href="/comics">Manage Comics</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,26 +2,25 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>cammcomedy – Booked Comics</title>
+  <title>{{.Gig.Name}}</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <h1>🎤 cammcomedy</h1>
+  <h1>{{.Gig.Name}}</h1>
+  <p>{{.Gig.Description}}</p>
+  <h2>Add Event</h2>
   <form method="POST">
-    <input name="name" placeholder="Name" required>
     <input name="date" type="date" required>
-    <label><input name="paid" type="checkbox"> Paid</label>
-    <input name="notes" placeholder="Notes">
-    <button type="submit">Add Comic</button>
+    <input name="time" type="time" required>
+    <textarea name="timeline" placeholder="Timeline"></textarea>
+    <button type="submit">Add Event</button>
   </form>
+  <h2>Events</h2>
   <ul>
-    {{range .}}
-    <li>
-      <strong>{{.Name}}</strong> ({{.Date}})
-      {{if .Paid}}✅ Paid{{else}}💸 Unpaid{{end}} – {{.Notes}}
-    </li>
+    {{range .Events}}
+    <li><a href="/event?id={{.ID}}">{{.Date}} {{.Time}}</a></li>
     {{end}}
   </ul>
+  <p><a href="/comics">Manage Comics</a></p>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- add proper .gitignore
- redesign page templates and CSS
- implement gig, event, and comic data models
- persist data in `data/app.json`
- add pages to manage events and comics

## Testing
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68857b4323c083258071c1b92ce81215