### PR TITLE
Improve event overview layout

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -16,11 +16,31 @@
     <button type="submit">Add Event</button>
   </form>
   <h2>Events</h2>
-  <ul>
-    {{range .Events}}
-    <li><a href="/event?id={{.ID}}">{{.Date}} {{.Time}}</a></li>
-    {{end}}
-  </ul>
+  <table>
+    <thead>
+      <tr>
+        <th>Event</th>
+        {{range .Headers}}
+        <th>{{.}}</th>
+        {{end}}
+      </tr>
+    </thead>
+    <tbody>
+      {{range .Events}}
+      <tr>
+        <td><a href="/event?id={{.ID}}">{{.Date}} {{.Time}}</a></td>
+        {{range $i := $.Indices}}
+          {{if lt $i (len .Comics)}}
+            {{$comic := index $.ComicMap (index .Comics $i).ComicID}}
+            <td>{{$comic.Name}}</td>
+          {{else}}
+            <td></td>
+          {{end}}
+        {{end}}
+      </tr>
+      {{end}}
+    </tbody>
+  </table>
   <p><a href="/comics">Manage Comics</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show event lineups in a table on the main page
- add helper for generating index slices

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68857d69aff883259646ed9a1218f451