### PR TITLE
Improve styling and mobile UX

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,26 +1,76 @@
-body {
-  font-family: system-ui, sans-serif;
-  max-width: 700px;
-  margin: 2rem auto;
-  padding: 0 1rem;
-  background: #fdfdfd;
-  color: #222;
+:root {
+  --bg: #fff8e1;
+  --fg: #211f1f;
+  --accent: #ff5722;
+  --accent2: #795548;
+  --heading-font: 'Cooper Black', Impact, fantasy, sans-serif;
+  --body-font: 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
-h1 {
-  font-size: 2rem;
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #2b2626;
+    --fg: #f7e9d9;
+    --accent: #ff8c00;
+    --accent2: #6d4c41;
+  }
+}
+
+body {
+  font-family: var(--body-font);
+  line-height: 1.6;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+  max-width: 700px;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+h1,
+h2,
+h3 {
+  font-family: var(--heading-font);
+  color: var(--accent);
   margin-bottom: 1rem;
 }
 
 form {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.75rem;
   margin-bottom: 2rem;
   padding: 1rem;
-  background: #fff;
+  background: var(--bg);
+  border: 2px solid var(--accent2);
+  border-radius: 6px;
+}
+
+input,
+select,
+button {
+  font-size: 1rem;
+  padding: 0.5rem;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+button {
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  border: none;
+}
+
+button:hover,
+button:focus {
+  background: var(--accent2);
+}
+
+button:focus,
+input:focus,
+select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 ul {
@@ -32,8 +82,45 @@ li {
   margin-bottom: 0.5rem;
 }
 
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent2);
+  text-decoration: underline;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th,
+td {
+  padding: 0.5rem;
+  border-bottom: 1px solid #ccc;
+  text-align: left;
+}
+
 label {
   display: flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+@media (min-width: 600px) {
+  form.horizontal {
+    flex-direction: row;
+    align-items: flex-end;
+  }
+  form.horizontal > * {
+    margin-right: 0.5rem;
+  }
+  form.horizontal button {
+    margin-right: 0;
+  }
 }

--- a/templates/comics.html
+++ b/templates/comics.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Comics</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <h1>Comics</h1>
-<form method="POST">
+<form method="POST" class="horizontal">
   <input name="name" placeholder="Name" required>
   <button type="submit">Add Comic</button>
 </form>

--- a/templates/event.html
+++ b/templates/event.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Event {{.Event.Date}}</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <h1>{{.Event.Date}} {{.Event.Time}}</h1>
 <h2>Add Performer</h2>
-<form method="POST">
+<form method="POST" class="horizontal">
   <select name="comic_id">
     {{range .Comics}}
     <option value="{{.ID}}">{{.Name}}</option>

--- a/templates/gig.html
+++ b/templates/gig.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{{.Gig.Name}}</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
@@ -9,7 +10,7 @@
 <h1>{{.Gig.Name}}</h1>
 <p>{{.Gig.Recurrence}}</p>
 <h2>Add Event</h2>
-<form method="POST">
+<form method="POST" class="horizontal">
   <input name="date" type="date" required>
   <input name="time" type="time" required>
   <button type="submit">Add Event</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,12 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Gigs</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
 <h1>Gigs</h1>
-<form method="POST">
+<form method="POST" class="horizontal">
   <input name="name" placeholder="Gig name" required>
   <input name="recurrence" placeholder="Recurrence">
   <button type="submit">Add Gig</button>


### PR DESCRIPTION
## Summary
- enhance CSS with responsive layout and accessible focus styles
- add viewport meta tags to HTML templates
- make some forms responsive with a `horizontal` class
- refresh the CSS with a 70s vibe and automatic dark mode

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885818a2c708325b0133190ad07c7b9