### PR TITLE
Add comic details management and friendly event names

### DIFF
--- a/templates/comic.html
+++ b/templates/comic.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Edit Comic</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+<h1>Edit Comic</h1>
+<form method="POST">
+  <input name="name" placeholder="Name" value="{{.Name}}" required>
+  <input name="contact" placeholder="Contact" value="{{.Contact}}">
+  <input name="fee" placeholder="Default fee" value="{{.DefaultFee}}">
+  <textarea name="bio" placeholder="Bio">{{.Bio}}</textarea>
+  <textarea name="notes" placeholder="Notes">{{.Notes}}</textarea>
+  <button type="submit">Save</button>
+  <button type="submit" name="delete" value="1" onclick="return confirm('Delete this comic?');">Delete</button>
+</form>
+<p><a href="/comics">Back</a></p>
+</body>
+</html>

--- a/templates/comics.html
+++ b/templates/comics.html
@@ -8,13 +8,17 @@
 </head>
 <body>
 <h1>Comics</h1>
-<form method="POST" class="horizontal">
+<form method="POST">
   <input name="name" placeholder="Name" required>
+  <input name="contact" placeholder="Contact">
+  <input name="fee" placeholder="Default fee">
+  <textarea name="bio" placeholder="Bio"></textarea>
+  <textarea name="notes" placeholder="Notes"></textarea>
   <button type="submit">Add Comic</button>
 </form>
 <ul>
   {{range .}}
-  <li>{{.Name}}</li>
+  <li><a href="/comic?id={{.ID}}">{{.Name}}</a></li>
   {{end}}
 </ul>
 <p><a href="/">Back</a></p>

--- a/templates/event.html
+++ b/templates/event.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Event {{.Event.Date}}</title>
+  <title>{{.Event.Name}}</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-<h1>{{.Event.Date}} {{.Event.Time}}</h1>
+<h1>{{.Event.Name}}</h1>
 <h2>Add Performer</h2>
 <form method="POST" class="horizontal">
   <select name="comic_id">

--- a/templates/gig.html
+++ b/templates/gig.html
@@ -23,7 +23,7 @@
   <tbody>
     {{range .Events}}
     <tr>
-      <td><a href="/event?id={{.ID}}">{{.Date}} {{.Time}}</a></td>
+      <td><a href="/event?id={{.ID}}">{{.Name}}</a></td>
       <td>{{.MC}}</td>
       <td>{{.Headliner}}</td>
       <td>{{range $i,$c := .Comics}}{{if $i}}, {{end}}{{$c}}{{end}}</td>


### PR DESCRIPTION
## Summary
- format event names using a friendly date
- extend comics with bio, notes, contact and default fee
- allow adding, editing and deleting comics
- show friendly event names in the UI

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68858b069d088325aa439297b9240194