### PR TITLE
Add role dropdown and unique MC/Headliner checks

### DIFF
--- a/main.go
+++ b/main.go
@@ -243,6 +243,16 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 		comicID := r.FormValue("comic_id")
 		role := r.FormValue("role")
 		if comicID != "" && role != "" {
+			// disallow multiple MCs or Headliners
+			if role == "MC" || role == "HEADLINER" {
+				var cnt int
+				db.QueryRow("SELECT COUNT(*) FROM lineup WHERE event_id=? AND role=?", id, role).Scan(&cnt)
+				if cnt > 0 {
+					http.Error(w, role+" already assigned", http.StatusBadRequest)
+					return
+				}
+			}
+
 			// find max position for comics
 			var pos sql.NullInt64
 			if role == "COMIC" {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -55,5 +60,96 @@ func TestFetchComics(t *testing.T) {
 	}
 	if comics[0].Name != "Anna" || comics[1].Name != "Zed" {
 		t.Fatalf("comics not sorted by name: %#v", comics)
+	}
+}
+
+func addTestEvent(t *testing.T) (eventID int64) {
+	res, err := db.Exec("INSERT INTO gigs(name) VALUES('Gig')")
+	if err != nil {
+		t.Fatalf("insert gig: %v", err)
+	}
+	gid, _ := res.LastInsertId()
+	res, err = db.Exec("INSERT INTO events(gig_id, date, time) VALUES(?,?,?)", gid, "2024-01-01", "20:00")
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ = res.LastInsertId()
+	return
+}
+
+func addComic(t *testing.T, name string) int64 {
+	res, err := db.Exec("INSERT INTO comics(name) VALUES(?)", name)
+	if err != nil {
+		t.Fatalf("insert comic: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestEventRoleDropdown(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/event?id="+strconv.FormatInt(eid, 10), nil)
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "<select name=\"role\"") || !strings.Contains(body, "MC") {
+		t.Fatalf("role dropdown missing")
+	}
+}
+
+func TestDuplicateMCNotAllowed(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+	c1 := addComic(t, "One")
+	c2 := addComic(t, "Two")
+
+	// first MC
+	form := url.Values{"comic_id": {strconv.FormatInt(c1, 10)}, "role": {"MC"}}
+	req := httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", w.Code)
+	}
+
+	// second MC should fail
+	form.Set("comic_id", strconv.FormatInt(c2, 10))
+	req = httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDuplicateHeadlinerNotAllowed(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+	c1 := addComic(t, "H1")
+	c2 := addComic(t, "H2")
+
+	form := url.Values{"comic_id": {strconv.FormatInt(c1, 10)}, "role": {"HEADLINER"}}
+	req := httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", w.Code)
+	}
+
+	form.Set("comic_id", strconv.FormatInt(c2, 10))
+	req = httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }


### PR DESCRIPTION
## Summary
- prevent duplicate MC or headliner assignments in `eventHandler`
- test the event page's role dropdown
- test duplicate MC/headliner restrictions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68859095fd488325a46df722de1b781f