### PR TITLE
Implement payment tracking for event lineup

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,8 @@ func initDB() error {
             comic_id INTEGER NOT NULL,
             role TEXT NOT NULL,
             position INTEGER,
+            fee TEXT,
+            paid INTEGER DEFAULT 0,
             FOREIGN KEY(event_id) REFERENCES events(id),
             FOREIGN KEY(comic_id) REFERENCES comics(id)
         );`)
@@ -77,6 +79,8 @@ func initDB() error {
 		"ALTER TABLE comics ADD COLUMN notes TEXT",
 		"ALTER TABLE comics ADD COLUMN contact TEXT",
 		"ALTER TABLE comics ADD COLUMN default_fee TEXT",
+		"ALTER TABLE lineup ADD COLUMN fee TEXT",
+		"ALTER TABLE lineup ADD COLUMN paid INTEGER DEFAULT 0",
 	}
 	for _, stmt := range alters {
 		if _, err := db.Exec(stmt); err != nil && !strings.Contains(err.Error(), "duplicate column") {
@@ -240,15 +244,31 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method == http.MethodPost {
+		if lid := r.FormValue("lineup_id"); lid != "" {
+			fee := r.FormValue("fee")
+			paid := 0
+			if r.FormValue("paid") != "" {
+				paid = 1
+			}
+			_, err := db.Exec("UPDATE lineup SET fee=?, paid=? WHERE id=?", fee, paid, lid)
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			http.Redirect(w, r, r.URL.String(), http.StatusSeeOther)
+			return
+		}
+
 		comicID := r.FormValue("comic_id")
 		role := r.FormValue("role")
+		fee := r.FormValue("fee")
 		if comicID != "" && role != "" {
 			// find max position for comics
 			var pos sql.NullInt64
 			if role == "COMIC" {
 				db.QueryRow("SELECT COALESCE(MAX(position),0)+1 FROM lineup WHERE event_id=? AND role='COMIC'", id).Scan(&pos)
 			}
-			_, err := db.Exec("INSERT INTO lineup(event_id, comic_id, role, position) VALUES(?,?,?,?)", id, comicID, role, pos.Int64)
+			_, err := db.Exec("INSERT INTO lineup(event_id, comic_id, role, position, fee) VALUES(?,?,?,?,?)", id, comicID, role, pos.Int64, fee)
 			if err != nil {
 				http.Error(w, err.Error(), 500)
 				return
@@ -268,17 +288,21 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 	comics, _ := fetchComics()
 
 	// fetch lineup
-	lrows, _ := db.Query("SELECT lineup.id, comics.name, role, position FROM lineup JOIN comics ON lineup.comic_id = comics.id WHERE event_id=? ORDER BY role, position", id)
+	lrows, _ := db.Query("SELECT lineup.id, comics.name, role, fee, paid, position FROM lineup JOIN comics ON lineup.comic_id = comics.id WHERE event_id=? ORDER BY role, position", id)
 	type LineupItem struct {
 		ID   int
 		Name string
 		Role string
+		Fee  string
+		Paid bool
 	}
 	var lineup []LineupItem
 	for lrows.Next() {
 		var li LineupItem
 		var pos sql.NullInt64
-		lrows.Scan(&li.ID, &li.Name, &li.Role, &pos)
+		var paid int
+		lrows.Scan(&li.ID, &li.Name, &li.Role, &li.Fee, &paid, &pos)
+		li.Paid = paid == 1
 		lineup = append(lineup, li)
 	}
 	lrows.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -27,6 +27,10 @@ func TestInitDBCreatesTables(t *testing.T) {
 			t.Errorf("expected table %s to exist: %v", tbl, err)
 		}
 	}
+
+	if _, err := db.Query("SELECT fee, paid FROM lineup LIMIT 1"); err != nil {
+		t.Errorf("expected columns fee and paid in lineup: %v", err)
+	}
 }
 
 func TestFetchComics(t *testing.T) {

--- a/templates/event.html
+++ b/templates/event.html
@@ -20,12 +20,21 @@
     <option value="HEADLINER">Headliner</option>
     <option value="COMIC">Comic</option>
   </select>
+  <input name="fee" placeholder="Fee">
   <button type="submit">Add</button>
 </form>
 <h2>Lineup</h2>
 <ul>
   {{range .Lineup}}
-  <li>{{.Role}} - {{.Name}}</li>
+  <li>
+    <form method="POST" class="horizontal">
+      <span>{{.Role}} - {{.Name}}</span>
+      <input name="fee" value="{{.Fee}}" placeholder="Fee">
+      <label><input type="checkbox" name="paid" value="1" {{if .Paid}}checked{{end}}> Paid</label>
+      <input type="hidden" name="lineup_id" value="{{.ID}}">
+      <button type="submit">Save</button>
+    </form>
+  </li>
   {{end}}
 </ul>
 <p><a href="/gig?id={{.Event.GigID}}">Back to Gig</a></p>


### PR DESCRIPTION
## Summary
- add `fee` and `paid` fields to the lineup table
- expose fields with schema updates for existing DBs
- allow updating fee and paid status from the event page
- show and edit payment info in the event lineup
- cover new DB columns in tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6885909ec4788325a488a165c2aecd6c