### PR TITLE
Enable event deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -240,6 +241,23 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method == http.MethodPost {
+		if r.FormValue("delete") != "" {
+			var gigID int
+			if err := db.QueryRow("SELECT gig_id FROM events WHERE id=?", id).Scan(&gigID); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			if _, err := db.Exec("DELETE FROM lineup WHERE event_id=?", id); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			if _, err := db.Exec("DELETE FROM events WHERE id=?", id); err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			http.Redirect(w, r, "/gig?id="+strconv.Itoa(gigID), http.StatusSeeOther)
+			return
+		}
 		comicID := r.FormValue("comic_id")
 		role := r.FormValue("role")
 		if comicID != "" && role != "" {

--- a/templates/event.html
+++ b/templates/event.html
@@ -28,6 +28,9 @@
   <li>{{.Role}} - {{.Name}}</li>
   {{end}}
 </ul>
+<form method="POST" onsubmit="return confirm('Delete this event?');">
+  <button type="submit" name="delete" value="1">Delete Event</button>
+</form>
 <p><a href="/gig?id={{.Event.GigID}}">Back to Gig</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `strconv` import
- support deleting events by POSTing `delete` to `/event`
- expose `Delete Event` button in event template

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688590d61d6883259fdfa7e951ec18a2