### PR TITLE
Add search and sort with payment tracking

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -33,7 +33,7 @@ func TestFetchComics(t *testing.T) {
 	setupTestDB(t)
 
 	// empty initially
-	comics, err := fetchComics()
+	comics, err := fetchComics("")
 	if err != nil {
 		t.Fatalf("fetchComics failed: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestFetchComics(t *testing.T) {
 		t.Fatalf("insert comics: %v", err)
 	}
 
-	comics, err = fetchComics()
+	comics, err = fetchComics("")
 	if err != nil {
 		t.Fatalf("fetchComics failed: %v", err)
 	}

--- a/templates/comics.html
+++ b/templates/comics.html
@@ -8,6 +8,11 @@
 </head>
 <body>
 <h1>Comics</h1>
+<form method="GET" class="horizontal">
+  <input name="q" placeholder="Search" value="{{.Query}}">
+  <button type="submit">Search</button>
+  <a href="/comics">Clear</a>
+</form>
 <form method="POST">
   <input name="name" placeholder="Name" required>
   <input name="contact" placeholder="Contact">
@@ -17,7 +22,7 @@
   <button type="submit">Add Comic</button>
 </form>
 <ul>
-  {{range .}}
+  {{range .Comics}}
   <li><a href="/comic?id={{.ID}}">{{.Name}}</a></li>
   {{end}}
 </ul>

--- a/templates/event.html
+++ b/templates/event.html
@@ -25,7 +25,19 @@
 <h2>Lineup</h2>
 <ul>
   {{range .Lineup}}
-  <li>{{.Role}} - {{.Name}}</li>
+  <li>
+    {{.Role}} - {{.Name}}
+    <form method="POST" style="display:inline">
+      <input type="hidden" name="lineup_id" value="{{.ID}}">
+      {{if .Paid}}
+      <input type="hidden" name="paid" value="0">
+      <button type="submit">Unmark Paid</button>
+      {{else}}
+      <input type="hidden" name="paid" value="1">
+      <button type="submit">Mark Paid</button>
+      {{end}}
+    </form>
+  </li>
   {{end}}
 </ul>
 <p><a href="/gig?id={{.Event.GigID}}">Back to Gig</a></p>

--- a/templates/gig.html
+++ b/templates/gig.html
@@ -16,10 +16,15 @@
   <button type="submit">Add Event</button>
 </form>
 <h2>Events</h2>
+<p>
+  <a href="?upcoming=1">Upcoming</a> |
+  <a href="?">All</a> |
+  <a href="?unpaid=1">Unpaid</a>
+</p>
 <table>
   <thead>
     <tr>
-      <th>Date</th>
+      <th><a href="?sort={{if eq .Sort "date"}}date_desc{{else}}date{{end}}">Date</a></th>
       <th>MC</th>
       <th>Headliner</th>
       <th>Comic 1</th>


### PR DESCRIPTION
## Summary
- allow marking lineup items as paid
- filter and sort events in gig view
- search comics by name
- update templates for sorting, filtering, and payment buttons

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_688590aedd288325a14164fca0c45cbe