### PR TITLE
Improve event notes UX

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,6 @@ func eventHandler(w http.ResponseWriter, r *http.Request) {
 			http.Redirect(w, r, r.URL.String(), http.StatusSeeOther)
 			return
 		}
-
 		if lid := r.FormValue("lineup_id"); lid != "" {
 			fee := r.FormValue("fee")
 			paid := 0

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -26,6 +31,10 @@ func TestInitDBCreatesTables(t *testing.T) {
 		if _, err := db.Query("SELECT * FROM " + tbl + " LIMIT 1"); err != nil {
 			t.Errorf("expected table %s to exist: %v", tbl, err)
 		}
+	}
+
+	if _, err := db.Query("SELECT fee, paid FROM lineup LIMIT 1"); err != nil {
+		t.Errorf("expected columns fee and paid in lineup: %v", err)
 	}
 }
 
@@ -55,5 +64,96 @@ func TestFetchComics(t *testing.T) {
 	}
 	if comics[0].Name != "Anna" || comics[1].Name != "Zed" {
 		t.Fatalf("comics not sorted by name: %#v", comics)
+	}
+}
+
+func addTestEvent(t *testing.T) (eventID int64) {
+	res, err := db.Exec("INSERT INTO gigs(name) VALUES('Gig')")
+	if err != nil {
+		t.Fatalf("insert gig: %v", err)
+	}
+	gid, _ := res.LastInsertId()
+	res, err = db.Exec("INSERT INTO events(gig_id, date, time) VALUES(?,?,?)", gid, "2024-01-01", "20:00")
+	if err != nil {
+		t.Fatalf("insert event: %v", err)
+	}
+	eventID, _ = res.LastInsertId()
+	return
+}
+
+func addComic(t *testing.T, name string) int64 {
+	res, err := db.Exec("INSERT INTO comics(name) VALUES(?)", name)
+	if err != nil {
+		t.Fatalf("insert comic: %v", err)
+	}
+	id, _ := res.LastInsertId()
+	return id
+}
+
+func TestEventRoleDropdown(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/event?id="+strconv.FormatInt(eid, 10), nil)
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "<select name=\"role\"") || !strings.Contains(body, "MC") {
+		t.Fatalf("role dropdown missing")
+	}
+}
+
+func TestDuplicateMCNotAllowed(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+	c1 := addComic(t, "One")
+	c2 := addComic(t, "Two")
+
+	// first MC
+	form := url.Values{"comic_id": {strconv.FormatInt(c1, 10)}, "role": {"MC"}}
+	req := httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", w.Code)
+	}
+
+	// second MC should fail
+	form.Set("comic_id", strconv.FormatInt(c2, 10))
+	req = httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestDuplicateHeadlinerNotAllowed(t *testing.T) {
+	setupTestDB(t)
+	eid := addTestEvent(t)
+	c1 := addComic(t, "H1")
+	c2 := addComic(t, "H2")
+
+	form := url.Values{"comic_id": {strconv.FormatInt(c1, 10)}, "role": {"HEADLINER"}}
+	req := httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusSeeOther {
+		t.Fatalf("expected redirect, got %d", w.Code)
+	}
+
+	form.Set("comic_id", strconv.FormatInt(c2, 10))
+	req = httptest.NewRequest(http.MethodPost, "/event?id="+strconv.FormatInt(eid, 10), strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w = httptest.NewRecorder()
+	eventHandler(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }

--- a/static/event.js
+++ b/static/event.js
@@ -1,0 +1,16 @@
+(function(){
+  const select = document.getElementById('comicSelect');
+  const info = document.getElementById('comicInfo');
+  const feeInput = document.getElementById('feeInput');
+  if(!select || !info || !feeInput) return;
+  function update(){
+    const opt = select.options[select.selectedIndex];
+    const bio = opt.dataset.bio || '';
+    const notes = opt.dataset.notes || '';
+    const fee = opt.dataset.fee || '';
+    info.textContent = bio || notes || '';
+    feeInput.placeholder = fee;
+  }
+  select.addEventListener('change', update);
+  update();
+})();

--- a/templates/comics.html
+++ b/templates/comics.html
@@ -18,7 +18,17 @@
 </form>
 <ul>
   {{range .}}
-  <li><a href="/comic?id={{.ID}}">{{.Name}}</a></li>
+  <li>
+    <details>
+      <summary><a href="/comic?id={{.ID}}">{{.Name}}</a></summary>
+      {{if .Bio}}
+      <p><strong>Bio:</strong> {{.Bio}}</p>
+      {{end}}
+      {{if .Notes}}
+      <p><strong>Notes:</strong> {{.Notes}}</p>
+      {{end}}
+    </details>
+  </li>
   {{end}}
 </ul>
 <p><a href="/">Back</a></p>

--- a/templates/event.html
+++ b/templates/event.html
@@ -20,6 +20,7 @@
     <option value="HEADLINER">Headliner</option>
     <option value="COMIC">Comic</option>
   </select>
+  <input name="fee" placeholder="Fee">
   <button type="submit">Add</button>
 </form>
 <h2>Run Sheet</h2>
@@ -30,7 +31,15 @@
 <h2>Lineup</h2>
 <ul>
   {{range .Lineup}}
-  <li>{{.Role}} - {{.Name}}</li>
+  <li>
+    <form method="POST" class="horizontal">
+      <span>{{.Role}} - {{.Name}}</span>
+      <input name="fee" value="{{.Fee}}" placeholder="Fee">
+      <label><input type="checkbox" name="paid" value="1" {{if .Paid}}checked{{end}}> Paid</label>
+      <input type="hidden" name="lineup_id" value="{{.ID}}">
+      <button type="submit">Save</button>
+    </form>
+  </li>
   {{end}}
 </ul>
 <p><a href="/gig?id={{.Event.GigID}}">Back to Gig</a></p>

--- a/templates/event.html
+++ b/templates/event.html
@@ -9,10 +9,10 @@
 <body>
 <h1>{{.Event.Name}}</h1>
 <h2>Add Performer</h2>
-<form method="POST" class="horizontal">
-  <select name="comic_id">
+<form method="POST" class="horizontal" id="addLineupForm">
+  <select name="comic_id" id="comicSelect">
     {{range .Comics}}
-    <option value="{{.ID}}">{{.Name}}</option>
+    <option value="{{.ID}}" data-bio="{{js .Bio}}" data-notes="{{js .Notes}}" data-fee="{{.DefaultFee}}">{{.Name}}</option>
     {{end}}
   </select>
   <select name="role">
@@ -20,9 +20,10 @@
     <option value="HEADLINER">Headliner</option>
     <option value="COMIC">Comic</option>
   </select>
-  <input name="fee" placeholder="Fee">
+  <input name="fee" id="feeInput" placeholder="Fee">
   <button type="submit">Add</button>
 </form>
+<div id="comicInfo"></div>
 <h2>Run Sheet</h2>
 <form method="POST">
   <textarea name="notes" placeholder="Run Sheet/Notes">{{.Event.Notes}}</textarea>
@@ -43,5 +44,6 @@
   {{end}}
 </ul>
 <p><a href="/gig?id={{.Event.GigID}}">Back to Gig</a></p>
+<script src="/static/event.js"></script>
 </body>
 </html>

--- a/templates/event.html
+++ b/templates/event.html
@@ -22,6 +22,11 @@
   </select>
   <button type="submit">Add</button>
 </form>
+<h2>Run Sheet</h2>
+<form method="POST">
+  <textarea name="notes" placeholder="Run Sheet/Notes">{{.Event.Notes}}</textarea>
+  <button type="submit" name="update_notes" value="1">Save</button>
+</form>
 <h2>Lineup</h2>
 <ul>
   {{range .Lineup}}

--- a/templates/gig.html
+++ b/templates/gig.html
@@ -43,7 +43,7 @@
       <td>{{index .Comics 3}}</td>
       <td>{{index .Comics 4}}</td>
       <td>{{index .Comics 5}}</td>
-      <td>{{.Timeline}}</td>
+      <td>{{.Notes}}</td>
     </tr>
     {{end}}
   </tbody>


### PR DESCRIPTION
## Summary
- rename event field `Timeline` to `Notes`
- show editable Run Sheet section on event page
- display comic bios and notes in expandable details

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_688590ab2c4883259339f585d439d56e